### PR TITLE
Update Moralis api handling to use `cursor` pagination

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,8 @@ const PageLimit = 50;
 
 function App() {
   const [ethPage, setEthPage] = useState(0);
-  const [l2Page, setL2Page] = useState(0);
-  const [domainOwner, setDomainOwner] = useState("");
+  const [l2Cursor, setL2Cursor] = useState<string | undefined>('');
+  const [domainOwner, setDomainOwner] = useState('');
   const [nfts, setNfts] = useState([] as Nft[]);
   const [loading, setLoading] = useState(true);
   const [isAllEthNftsLoaded, setIsAllEthNftsLoaded] = useState(false); // No need to trigger a request when true
@@ -60,15 +60,13 @@ function App() {
     if (isAllL2NftsLoaded) {
       return [];
     }
-    const { nfts: _nfts, received } = await getNfts(
-      `https://unstoppabledomains.com/api/nfts/l2?offset=${
-        l2Page * PageLimit
-      }&limit=${PageLimit}&ownerAddress=${domainOwner}&chain=polygon`
+    const { nfts: _nfts, received, cursor } = await getNfts(
+      `https://unstoppabledomains.com/api/nfts/l2?limit=${PageLimit}&ownerAddress=${domainOwner}&chain=polygon&cursor=${l2Cursor}`
     );
     if (received < PageLimit) {
       setIsAllL2NftsLoaded(true);
     }
-    setL2Page(l2Page + 1);
+    setL2Cursor(cursor);
     return _nfts;
   };
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -57,8 +57,8 @@ export const getNfts = async (
   url: string
 ): Promise<{ nfts: Array<Nft>; received: number, cursor?: string }> => {
   const resp = await fetch(url);
-  const { nfts }: { nfts: UdNft[] } = await resp.json();
+  const { nfts, cursor }: { nfts: UdNft[], cursor?: string } = await resp.json();
   const cleaned = cleanNfts(nfts);
 
-  return { nfts: cleaned, received: nfts.length };
+  return { nfts: cleaned, received: nfts.length, cursor};
 };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -55,7 +55,7 @@ const cleanNfts = (nfts: UdNft[]): Nft[] => {
 
 export const getNfts = async (
   url: string
-): Promise<{ nfts: Array<Nft>; received: number }> => {
+): Promise<{ nfts: Array<Nft>; received: number, cursor?: string }> => {
   const resp = await fetch(url);
   const { nfts }: { nfts: UdNft[] } = await resp.json();
   const cleaned = cleanNfts(nfts);


### PR DESCRIPTION
## Background

<!-- Why is this PR necessary? -->
https://unstoppabledomains.slack.com/archives/C02P0QWAYG7/p1654128473089079
The Moralis API has been [updated](https://github.com/MoralisWeb3/changelog/blob/main/2022-06-01.md) unexpectedly and they moved from the offset pagination to [cursor pagination](https://docs.moralis.io/misc/rate-limit#example-of-how-to-use-cursor-nodejs), so we are not able to fetch the NFTs until we also change our endpoint to use the cursor pagination.
